### PR TITLE
Add "All Tests" link to footer and navigation menu

### DIFF
--- a/components/ui/footer/footer-section.tsx
+++ b/components/ui/footer/footer-section.tsx
@@ -29,6 +29,7 @@ import {
   Brain,
   MessageCircle,
   PencilLine,
+  BookOpenCheck,
 } from "lucide-react";
 import Link from "next/link";
 import { useUser } from "@clerk/nextjs";
@@ -55,6 +56,7 @@ function Footerdemo() {
   const [conversationPath, setConversationPath] =
     useState<string>("/conversation");
   const [testPath, setTestPath] = useState<string>("/test");
+  const [allTestsPath, setAllTestsPath] = useState<string>("/allTests");
 
   const quickLinks = isSignedIn
     ? [
@@ -62,6 +64,7 @@ function Footerdemo() {
         { name: "Ask Question", url: "/ask-question", icon: FileQuestion },
         { name: "Ask AI", url: chatPath, icon: Brain },
         { name: "Test", url: testPath, icon: PencilLine },
+        { name: "All Tests", url: allTestsPath, icon: BookOpenCheck },
         { name: "Conversations", url: conversationPath, icon: MessageCircle },
         { name: "Dashboard", url: dashboardPath, icon: LayoutDashboard },
         { name: "Saved", url: savedPath, icon: Bookmark },
@@ -151,6 +154,13 @@ function Footerdemo() {
       const searchString = searchParams.toString();
       const fullPath = searchString ? `/test?${searchString}` : "/test";
       setTestPath(fullPath);
+    }
+    if (pathname === "/allTests") {
+      const searchString = searchParams.toString();
+      const fullPath = searchString
+        ? `/allTests?${searchString}`
+        : "/allTests";
+      setAllTestsPath(fullPath);
     }
   }, [pathname, searchParams]);
 

--- a/components/ui/navbar/scroll-navigation-menu.tsx
+++ b/components/ui/navbar/scroll-navigation-menu.tsx
@@ -22,6 +22,7 @@ import {
   X,
   MessageCircle,
   PencilLine,
+  BookOpenCheck,
 } from "lucide-react";
 import Link from "next/link";
 import * as React from "react";
@@ -62,6 +63,7 @@ export const ScrollNavigationMenu: React.FC<ScrollNavbarProps> = ({
   const [conversationPath, setConversationPath] =
     useState<string>("/conversation");
   const [testPath, setTestPath] = useState<string>("/test");
+  const [allTestsPath, setAllTestsPath] = useState<string>("/allTests");
 
   const menuItems: MenuItem[] = isSignedIn
     ? [
@@ -91,36 +93,42 @@ export const ScrollNavigationMenu: React.FC<ScrollNavbarProps> = ({
         },
         {
           id: 5,
+          title: "All Tests",
+          url: allTestsPath,
+          icon: BookOpenCheck,
+        },
+        {
+          id: 6,
           title: "Conversations",
           url: conversationPath,
           icon: MessageCircle,
         },
         {
-          id: 6,
+          id: 7,
           title: "Dashboard",
           url: dashboardPath,
           icon: LayoutDashboard,
         },
         {
-          id: 7,
+          id: 8,
           title: "Saved",
           url: savedPath,
           icon: Bookmark,
         },
         {
-          id: 8,
+          id: 9,
           title: "Community",
           url: communityPath,
           icon: Users,
         },
         {
-          id: 9,
+          id: 10,
           title: "Popular Tags",
           url: popularTagsPath,
           icon: Tag,
         },
         {
-          id: 10,
+          id: 11,
           title: "Popular Subjects",
           url: popularSubjectsPath,
           icon: Book,
@@ -209,6 +217,13 @@ export const ScrollNavigationMenu: React.FC<ScrollNavbarProps> = ({
       const searchString = searchParams.toString();
       const fullPath = searchString ? `/test?${searchString}` : "/test";
       setTestPath(fullPath);
+    }
+    if (pathname === "/allTests") {
+      const searchString = searchParams.toString();
+      const fullPath = searchString
+        ? `/allTests?${searchString}`
+        : "/allTests";
+      setAllTestsPath(fullPath);
     }
   }, [pathname, searchParams]);
 


### PR DESCRIPTION
- Introduced a new "All Tests" path in both the footer and scroll navigation menu.
- Updated state management to handle the new path and its associated search parameters.
- Integrated the BookOpenCheck icon for visual representation in the navigation.